### PR TITLE
Correct case of filename in #include directive

### DIFF
--- a/src/NBduinoLibrary.cpp
+++ b/src/NBduinoLibrary.cpp
@@ -9,7 +9,7 @@
 */
 
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <NBduinoLibrary.h>
 
 static SoftwareSerial mySerial(10, 11); //RX, TX


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.